### PR TITLE
Revert broken commit

### DIFF
--- a/src/App/index.js
+++ b/src/App/index.js
@@ -11,6 +11,7 @@ import Settings from '../Settings';
 import About from '../About';
 import ROUTES from '../static/routes.json';
 import './index.css';
+import { Segment } from 'semantic-ui-react';
 
 // eslint-disable-next-line react/display-name
 // const PageHoc = (Component, page) => ({ current, ...props }) =>
@@ -67,12 +68,61 @@ const App = () => {
         expanded={expandedNavBar}
         width={width}
       />
-      <Route exact path={ROUTES.Home} component={Home} />
-      <Route path={ROUTES.Browse} component={Browse} />
-      <Route path={ROUTES.Collections} component={Collections} />
-      <Route path={ROUTES.Settings} component={Settings} />
-      <Route path={ROUTES.About} component={About} />
-      <Route path={ROUTES.Conjugate} component={Home} />
+      <Route
+        exact
+        path={ROUTES.Home}
+        render={() => {
+          setPage('home');
+          return <Home />;
+        }}
+      />
+      <Route
+        path={ROUTES.Browse}
+        render={() => {
+          setPage('browse');
+          return <Browse />;
+        }}
+      />
+      <Route
+        path={ROUTES.Collections}
+        render={() => {
+          setPage('collections');
+          return <Collections />;
+        }}
+      />
+      <Route
+        path={ROUTES.Settings}
+        render={() => {
+          setPage('settings');
+          return <Settings />;
+        }}
+      />
+      <Route
+        path={ROUTES.About}
+        render={() => {
+          setPage('about');
+          return <About />;
+        }}
+      />
+      <Route
+        path={ROUTES.Conjugate}
+        render={() => {
+          setPage('home');
+          return <Home />;
+        }}
+      />
+      <Route
+        path="/github"
+        render={() => {
+          window.location = ROUTES.GitHub;
+          setPage('github');
+          return (
+            <Segment raised padded style={{ margin: '25vh auto', width: '80vw', height: 'auto' }}>
+              <h1 style={{ textAlign: 'center', fontSize: '5em' }}>Loading GitHub Page...</h1>
+            </Segment>
+          );
+        }}
+      />
     </Router>
   );
 };

--- a/src/Home/component/SearchBar.js
+++ b/src/Home/component/SearchBar.js
@@ -4,8 +4,6 @@ import PropTypes from 'prop-types';
 import { Icon, Search } from 'semantic-ui-react';
 import _ from 'lodash';
 
-const input = document.querySelector('#homeSearchInput');
-
 // eslint-disable-next-line no-unused-vars
 const SearchBar = ({ onFilterResults, onSearchClick, value, setValue, ...props }) => {
   let [_isLoading, _setIsLoading] = useState(false);
@@ -22,7 +20,7 @@ const SearchBar = ({ onFilterResults, onSearchClick, value, setValue, ...props }
     _handleSearchClick(result.title);
   };
   const _handleSearchClick = key => {
-    input.blur();
+    document.querySelector('#homeSearchInput').blur();
     onSearchClick(key);
   };
   const _handleSearchChange = (e, { value }) => {

--- a/src/static/routes.json
+++ b/src/static/routes.json
@@ -5,5 +5,5 @@
   "Settings": "/settings",
   "About": "/about",
   "Conjugate": "/conjugate",
-  "GitHub": "//github.com/photomz/cinco_minutos"
+  "GitHub": "https://github.com/photomz/cinco_minutos"
 }


### PR DESCRIPTION
When using the updated version of the homepage, the presence of hooks causes some elements to constantly update, even when undesirable. Along with some other mistakes (only using the `querySelector` once, for example) the commit is as a whole harmful to the progress of the project. The site fails to load on my machine. Therefore, I propose a reversion of this new version of the homepage (along with a new and improved UI).